### PR TITLE
Fix saving empty tags

### DIFF
--- a/formwidgets/Tagbox.php
+++ b/formwidgets/Tagbox.php
@@ -56,10 +56,14 @@ class TagBox extends FormWidgetBase
         $ids = [];
 
         foreach ($tags as $name) {
+            if (empty($name)) {
+                continue;
+            }
             $created = Tag::firstOrCreate(['name' => $name]);
 
             $ids[] = $created->id;
         }
+
         return $ids;
     }
     


### PR DESCRIPTION
Sometimes, form widget saves empty tag:

![snimek obrazovky 2016-03-21 v 10 33 58](https://cloud.githubusercontent.com/assets/374917/13914770/db81059e-ef50-11e5-9de5-dfed1c7ec75f.png)
