### PR TITLE
Load tags at component init

### DIFF
--- a/formwidgets/Tagbox.php
+++ b/formwidgets/Tagbox.php
@@ -30,8 +30,21 @@ class TagBox extends FormWidgetBase
     public function prepareVars()
     {
         $this->vars['id'] = $this->model->id;
+        $this->vars['tags'] = $this->loadTags();
     }
-    
+
+    public function loadTags()
+    {
+        $tags = [];
+
+        if ($this->model->tags) {
+            foreach($this->model->tags as $tag) {
+                $tags[] = $tag->name;
+            }
+        }
+
+        return implode(',', $tags);
+    }
 
     /**
      * load assets widgets
@@ -48,6 +61,8 @@ class TagBox extends FormWidgetBase
     /**
      * get tag id if exists or create it if not exists
      *
+     * @param string $value
+     *
      * @return array
      */
     public function getSaveValue($value)
@@ -60,7 +75,6 @@ class TagBox extends FormWidgetBase
                 continue;
             }
             $created = Tag::firstOrCreate(['name' => $name]);
-
             $ids[] = $created->id;
         }
 

--- a/formwidgets/tagbox/partials/_widgets.htm
+++ b/formwidgets/tagbox/partials/_widgets.htm
@@ -1,6 +1,6 @@
 <ul id="tags" class="tagHandlerContainer"></ul>
 
-<input type="hidden" name='Post[tags][]' class="tagbox" value="">
+<input type="hidden" name='Post[tags][]' class="tagbox" value="<?= $tags ?>">
 
 <script type="text/javascript">
 $(document).on('render', function() {
@@ -14,12 +14,10 @@ $(document).on('render', function() {
     });
 });
 
-$(window).on('load', function() {
-    tagbox();
-});
-
 function tagbox() {
     var tags = $('#tags').tagHandler('getTags');
-    $(".tagbox").val(tags);
+    if (tags.length > 0) {
+        $(".tagbox").val(tags);
+    }
 }
 </script>


### PR DESCRIPTION
Load tags at component init, which save one Ajax request and it's less magic.

This `$(window).on('load')` part was very unreliable on very slow connections (mobile, at train) and sometimes it didn't load any tag.
