### PR TITLE
Grave accent removed

### DIFF
--- a/components/RelatedPosts.php
+++ b/components/RelatedPosts.php
@@ -68,9 +68,9 @@ class RelatedPosts extends ComponentBase
             ->with('tags');
 
         $orderBy = DB::raw('(
-            select count(*) from `rahman_blogtags_posts_tags`
-            where `rahman_blogtags_posts_tags`.`post_id` = `rainlab_blog_posts`.`id`
-            and `rahman_blogtags_posts_tags`.`tag_id` in ('.implode(', ', $tagIds).'))');
+            select count(*) from rahman_blogtags_posts_tags
+            where rahman_blogtags_posts_tags.post_id = rainlab_blog_posts.id
+            and rahman_blogtags_posts_tags.tag_id in ('.implode(', ', $tagIds).'))');
 
         // order by most related tags
         $query->orderby($orderBy, 'desc');


### PR DESCRIPTION
Grave accent is not supported without escape in PostrgreSQL database. This removes grave accent and make plugin great again on postgres.